### PR TITLE
Add a vendored feature to both the botan and botan-sys crates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "botan-src/botan"]
+	path = botan-src/botan
+	url = https://github.com/randombit/botan.git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["botan", "botan-sys"]
+members = ["botan", "botan-src", "botan-sys"]

--- a/botan-src/Cargo.toml
+++ b/botan-src/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "botan-src"
-version = "0.1.0+2.15.0"
+version = "0.21500.0"
 authors = ["Rodolphe Breard <rodolphe@what.tf>"]
 description = "Sources of for Botan cryptography library"
 license = "MIT"

--- a/botan-src/Cargo.toml
+++ b/botan-src/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "botan-src"
+version = "0.1.0+2.15.0"
+authors = ["Rodolphe Breard <rodolphe@what.tf>"]
+description = "Sources of for Botan cryptography library"
+license = "MIT"
+edition = "2018"
+homepage = "https://botan.randombit.net/"
+repository = "https://github.com/randombit/botan-rs"
+readme = "README.md"
+categories = ["cryptography"]
+
+[badges]
+travis-ci = { repository = "randombit/botan-rs" }
+
+[badges.maintenance]
+status = "actively-developed"
+
+[dependencies]
+
+[[example]]
+name = "build"
+path = "examples/build.rs"

--- a/botan-src/README.md
+++ b/botan-src/README.md
@@ -1,0 +1,9 @@
+# botan-src
+
+This crate compiles the sources of the
+[Botan](https://botan.randombit.net/) cryptography library as a static
+library. It is supposed to be used by the
+[botan-sys](https://crates.io/crates/botan-sys) crate.
+
+A high level Rust interface built on this library is included in the
+[botan](https://crates.io/crates/botan) crate.

--- a/botan-src/examples/build.rs
+++ b/botan-src/examples/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let (lib_dir, include_dir) = botan_src::build();
+    println!("Library directory: {}", lib_dir);
+    println!("Include directory: {}", include_dir);
+}

--- a/botan-src/src/lib.rs
+++ b/botan-src/src/lib.rs
@@ -1,0 +1,51 @@
+use std::env;
+use std::path::PathBuf;
+use std::process::Command;
+
+const BUILD_ERROR_MSG: &str = "Unable to build botan.";
+const SRC_DIR_ERROR_MSG: &str = "Unable to find the source directory.";
+const SRC_DIR: &str = "botan";
+const INCLUDE_DIR: &str = "build/include/botan";
+
+macro_rules! pathbuf_to_string {
+    ($s: ident) => {
+        $s.to_str().expect(BUILD_ERROR_MSG).to_string()
+    };
+}
+
+fn configure(build_dir: &str) {
+    let mut configure = Command::new("python");
+    configure.arg("configure.py");
+    configure.arg(format!("--with-build-dir={}", build_dir));
+    configure.arg("--build-targets=static");
+    configure.arg("--without-documentation");
+    #[cfg(debug_assertions)]
+    configure.arg("--debug-mode");
+    configure
+        .spawn()
+        .expect(BUILD_ERROR_MSG)
+        .wait()
+        .expect(BUILD_ERROR_MSG);
+}
+
+fn make(build_dir: &str) {
+    Command::new("make")
+        .arg("-f")
+        .arg(format!("{}/Makefile", build_dir))
+        .spawn()
+        .expect(BUILD_ERROR_MSG)
+        .wait()
+        .expect(BUILD_ERROR_MSG);
+}
+
+pub fn build() -> (String, String) {
+    let src_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(SRC_DIR);
+    let build_dir = std::env::var_os("OUT_DIR").map_or(src_dir.to_owned(), PathBuf::from);
+    let build_dir = build_dir.join("botan");
+    let include_dir = build_dir.join(INCLUDE_DIR);
+    let build_dir = pathbuf_to_string!(build_dir);
+    env::set_current_dir(&src_dir).expect(SRC_DIR_ERROR_MSG);
+    configure(&build_dir);
+    make(&build_dir);
+    (build_dir, pathbuf_to_string!(include_dir))
+}

--- a/botan-src/src/lib.rs
+++ b/botan-src/src/lib.rs
@@ -13,6 +13,19 @@ macro_rules! pathbuf_to_string {
     };
 }
 
+macro_rules! add_env_arg {
+    ($cnf: ident, $env_name: expr, $arg_name: expr, $is_flag: expr) => {
+        if let Ok(val) = env::var($env_name) {
+            let arg = if $is_flag {
+                format!("{}", $arg_name)
+            } else {
+                format!("{}={}", $arg_name, val)
+            };
+            $cnf.arg(&arg);
+        }
+    };
+}
+
 fn configure(build_dir: &str) {
     let mut configure = Command::new("python");
     configure.arg("configure.py");
@@ -21,6 +34,80 @@ fn configure(build_dir: &str) {
     configure.arg("--without-documentation");
     #[cfg(debug_assertions)]
     configure.arg("--debug-mode");
+    add_env_arg!(configure, "BOTAN_CONFIGURE_OS", "--os", false);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_CPU", "--cpu", false);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_CC", "--cc", false);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_CC_MIN_VERSION", "--cc-min-version", false);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_CC_BIN", "--cc-bin", false);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_CC_API_FLAGS", "--cc-abi-flags", false);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_CXXFLAGS", "--cxxflags", false);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_EXTRA_CXXFLAGS", "--extra-cxxflags", false);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_LDFLAGS", "--ldflags", false);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_AR_COMMAND", "--ar-command", false);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_AR_OPTIONS", "--ar-options", false);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_MSVC_RUNTIME", "--msvc-runtime", false);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_WITH_ENDIAN", "--with-endian", false);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_WITH_OS_FEATURES", "--with-os-features", false);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_WITHOUT_OS_FEATURES", "--without-os-features", false);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_DISABLE_SSE2", "--disable-sse2", true);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_DISABLE_SSE3", "--disable-sse3", true);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_DISABLE_SSE4-1", "--disable-sse4.1", true);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_DISABLE_SSE4-2", "--disable-sse4.2", true);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_DISABLE_AVX2", "--disable-avx2", true);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_DISABLE_BMI2", "--disable-bmi2", true);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_DISABLE_RDRAND", "--disable-rdrand", true);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_DISABLE_RDSEED", "--disable-rdseed", true);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_DISABLE_AES_NI", "--disable-aes-ni", true);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_DISABLE_SHA_NI", "--disable-sha-ni", true);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_DISABLE_ALTIVEC", "--disable-altivec", true);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_DISABLE_NEON", "--disable-neon", true);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_DISABLE_ARMV8CRYPTO", "--disable-armv8crypto", true);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_DISABLE_POWERCRYPTO", "--disable-powercrypto", true);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_WITH_SANITIZERS", "--with-sanitizers", true);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_ENABLE_SANITIZERS", "--enable-sanitizers", false);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_WITHOUT_STACK_PROTECTOR", "--without-stack-protector", true);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_WITH_COVERAGE", "--with-coverage", true);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_WITH_COVERAGE_INFO", "--with-coverage-info", true);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_OPTIMIZE_FOR_SIZE", "--optimize-for-size", true);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_NO_OPTIMIZATIONS", "--no-optimizations", true);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_AMALGAMATION", "--amalgamation", true);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_SYSTEM_CERT_BUNDLE", "--system-cert-bundle", false);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_WITH_EXTERNAL_INCLUDEDIR", "--with-external-includedir", false);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_WITH_EXTERNAL_LIBDIR", "--with-external-libdir", false);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_DEFINE_BUILD_MACRO", "--define-build-macro", true);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_WITH_SYSROOT_DIR", "--with-sysroot-dir", false);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_WITH_OPENMP", "--with-openmp", true);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_LINK_METHOD", "--link-method", false);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_WITH_LOCAL_CONFIG", "--with-local-config", false);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_DISTRIBUTION_INFO", "--distribution-info", false);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_MAINTAINER_MODE", "--maintainer-mode", true);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_WERROR_MODE", "--werror-mode", true);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_NO_INSTALL_PYTHON_MODULE", "--no-install-python-module", true);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_WITH_PYTHON_VERSIONS", "--with-python-versions", false);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_WITH_VALGRIND", "--with-valgrind", true);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_UNSAFE_FUZZER_MODE", "--unsafe-fuzzer-mode", true);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_BUILD_FUZZERS", "--build-fuzzers", false);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_WITH_FUZZER_LIB", "--with-fuzzer-lib", false);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_BOOST_LIBRARY_NAME", "--boost-library-name", false);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_MODULE_POLICY", "--module-policy", false);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_ENABLE_MODULES", "--enable-modules", false);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_DISABLE_MODULES", "--disable-modules", false);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_MINIMIZED_BUILD", "--minimized-build", true);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_WITH_BOOST", "--with-boost", true);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_WITH_BZIP2", "--with-bzip2", true);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_WITH_LZMA", "--with-lzma", true);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_WITH_ZLIB", "--with-zlib", true);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_WITH_OPENSSL", "--with-openssl", true);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_WITH_COMMONCRYPTO", "--with-commoncrypto", true);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_WITH_SQLITE3", "--with-sqlite3", true);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_WITH_TPM", "--with-tpm", true);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_PROGRAM_SUFFIX", "--program-suffix", false);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_LIBRARY_SUFFIX", "--library-suffix", false);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_PREFIX", "--prefix", false);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_BINDIR", "--bindir", false);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_LIBDIR", "--libdir", false);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_MANDIR", "--mandir", false);
+    add_env_arg!(configure, "BOTAN_CONFIGURE_INCLUDEDIR", "--includedir", false);
     configure
         .spawn()
         .expect(BUILD_ERROR_MSG)
@@ -40,7 +127,7 @@ fn make(build_dir: &str) {
 
 pub fn build() -> (String, String) {
     let src_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(SRC_DIR);
-    let build_dir = std::env::var_os("OUT_DIR").map_or(src_dir.to_owned(), PathBuf::from);
+    let build_dir = env::var_os("OUT_DIR").map_or(src_dir.to_owned(), PathBuf::from);
     let build_dir = build_dir.join("botan");
     let include_dir = build_dir.join(INCLUDE_DIR);
     let build_dir = pathbuf_to_string!(build_dir);

--- a/botan-sys/Cargo.toml
+++ b/botan-sys/Cargo.toml
@@ -26,4 +26,4 @@ vendored = ["botan-src"]
 cty = { version = "0.2" }
 
 [build-dependencies]
-botan-src = { version = "0.1", optional = true, path = "../botan-src" }
+botan-src = { version = "0.21500", optional = true, path = "../botan-src" }

--- a/botan-sys/Cargo.toml
+++ b/botan-sys/Cargo.toml
@@ -18,5 +18,12 @@ travis-ci = { repository = "randombit/botan-rs" }
 [badges.maintenance]
 status = "actively-developed"
 
+[features]
+default = []
+vendored = ["botan-src"]
+
 [dependencies]
 cty = { version = "0.2" }
+
+[build-dependencies]
+botan-src = { version = "0.1", optional = true, path = "../botan-src" }

--- a/botan-sys/build.rs
+++ b/botan-sys/build.rs
@@ -1,3 +1,14 @@
 fn main() {
-    println!("cargo:rustc-link-lib=botan-2");
+    #[cfg(feature = "vendored")]
+    {
+        let (lib_dir, _) = botan_src::build();
+        println!("cargo:vendored=1");
+        println!("cargo:rustc-link-search=native={}", &lib_dir);
+        println!("cargo:rustc-link-lib=static=botan-2");
+        println!("cargo:rustc-flags=-l dylib=stdc++");
+    }
+    #[cfg(not(feature = "vendored"))]
+    {
+        println!("cargo:rustc-link-lib=botan-2");
+    }
 }

--- a/botan/Cargo.toml
+++ b/botan/Cargo.toml
@@ -26,3 +26,4 @@ cstr_core = { version = "0.1", optional = true }
 [features]
 default = []
 no-std = ["cstr_core/alloc"]
+vendored = ["botan-sys/vendored"]


### PR DESCRIPTION
This vendored feature works the same way as the one in the openssl crate. When activated, it uses the newly added botan-src crate to build Botan as a static library and then links to it instead of a dynamic one.

I guess this feature is, at least partly, what is expected in randombit/botan-rs#14.

Please note that the Botan source code is included as a [git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules) linked to its GitHub repository. When a new version of Botan is released, this submodule should be updated to the new tag, the crate version updated and then published.
About the crate version, I used the same format as the openssl-src crate: Botan's version is included in the metadata. This metadata is purely informational, it's here so one can quickly see which Botan version he's getting with the crate.

This work is obviously a start, many things can be improved. The two most important things I can see are the following: prevent the systematic compilation of Botan and allow the user to properly configure the build. For the later, I think the best way to do it is to use environment variables. I first thought os using features, but they are really not adapted to many situations.