### PR TITLE
Fix no_std builds

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,8 @@
 
+## 0.7.0 Not Yet Released
+
+- Fix a problem with no_std builds in Rust 1.36 and higher
+
 ## 0.6.1 2020-02-15
 
 - Fix some warnings under latest beta/nightly versions of Rust

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 This crate wraps the C API exposed by the [Botan](https://botan.randombit.net/)
 cryptography library. Botan 2.8.0 or higher is required.
 
-Rust 1.32.0 or later are supported.  `no_std` builds are supported,
+Rust 1.36.0 or later are supported.  `no_std` builds are supported,
 just use feature `no-std`.
 
 Currently the crate exposes ciphers, hashes, MACs, KDFs, password based

--- a/botan/Cargo.toml
+++ b/botan/Cargo.toml
@@ -21,7 +21,7 @@ status = "actively-developed"
 [dependencies]
 botan-sys = { version = "0.6.0", path = "../botan-sys" }
 cty = { version = "0.2" }
-cstr_core = { version = "0.1", optional = true }
+cstr_core = { version = "0.2", optional = true }
 
 [features]
 default = []

--- a/botan/src/lib.rs
+++ b/botan/src/lib.rs
@@ -5,7 +5,7 @@
 
 //! A wrapper for the Botan cryptography library
 
-#![cfg_attr(feature = "no-std", feature(alloc))]
+#![cfg_attr(feature = "no-std", feature(alloc_prelude))]
 #![cfg_attr(feature = "no-std", no_std)]
 
 #[cfg(feature = "no-std")]

--- a/botan/src/utils.rs
+++ b/botan/src/utils.rs
@@ -1,7 +1,7 @@
 use botan_sys::*;
 
 #[cfg(feature = "no-std")]
-pub(crate) use alloc::prelude::*;
+pub(crate) use alloc::prelude::v1::*;
 
 #[cfg(feature = "no-std")]
 pub(crate) use cstr_core::{CStr, CString};


### PR DESCRIPTION
Broken since Rust 1.36.0