### PR TITLE
Allow parallel make

### DIFF
--- a/botan-src/src/lib.rs
+++ b/botan-src/src/lib.rs
@@ -108,11 +108,14 @@ fn configure(build_dir: &str) {
     add_env_arg!(configure, "BOTAN_CONFIGURE_LIBDIR", "--libdir", false);
     add_env_arg!(configure, "BOTAN_CONFIGURE_MANDIR", "--mandir", false);
     add_env_arg!(configure, "BOTAN_CONFIGURE_INCLUDEDIR", "--includedir", false);
-    configure
+    let status = configure
         .spawn()
         .expect(BUILD_ERROR_MSG)
         .wait()
         .expect(BUILD_ERROR_MSG);
+    if !status.success() {
+        panic!("configure terminated unsuccessfully");
+    }
 }
 
 fn make(build_dir: &str) {

--- a/botan-src/src/lib.rs
+++ b/botan-src/src/lib.rs
@@ -119,8 +119,16 @@ fn configure(build_dir: &str) {
 }
 
 fn make(build_dir: &str) {
-    Command::new("make")
-        .arg("-f")
+    let mut cmd = Command::new("make");
+    // Set MAKEFLAGS to the content of CARGO_MAKEFLAGS
+    // to give jobserver (parallel builds) support to the
+    // spawned sub-make.
+    if let Ok(val) = env::var("CARGO_MAKEFLAGS") {
+        cmd.env("MAKEFLAGS", val);
+    } else {
+        eprintln!("Can't set MAKEFLAGS as CARGO_MAKEFLAGS couldn't be read");
+    }
+    cmd.arg("-f")
         .arg(format!("{}/Makefile", build_dir))
         .spawn()
         .expect(BUILD_ERROR_MSG)

--- a/botan-src/src/lib.rs
+++ b/botan-src/src/lib.rs
@@ -128,12 +128,15 @@ fn make(build_dir: &str) {
     } else {
         eprintln!("Can't set MAKEFLAGS as CARGO_MAKEFLAGS couldn't be read");
     }
-    cmd.arg("-f")
+    let status = cmd.arg("-f")
         .arg(format!("{}/Makefile", build_dir))
         .spawn()
         .expect(BUILD_ERROR_MSG)
         .wait()
         .expect(BUILD_ERROR_MSG);
+    if !status.success() {
+        panic!("make terminated unsuccessfully");
+    }
 }
 
 pub fn build() -> (String, String) {


### PR DESCRIPTION
Passes the right env variables to the sub-make so that it recognizes the cargo-provided jobserver.

Fixes #22