### PR TITLE
Support DSA, ElGamal, non-allocating interface for Cipher

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 - Add support for the zfec forward error correction API now
   available in Botan 3
 - Add more Wycheproof tests
+- Add support for loading DSA public and private keys using
+  ``Pubkey::load_dsa`` and ``Privkey::load_dsa``
 
 ## 0.9.2 2023-02-24
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,9 @@
   ``Pubkey::load_dsa`` and ``Privkey::load_dsa``
 - Add support for loading ElGamal public and private keys using
   ``Pubkey::load_elgamal`` and ``Privkey::load_elgamal``
+- Add an interface to ``Cipher`` that avoids a heap allocation during
+  encryption and decryption: ``Cipher::update_into`` and
+  ``Cipher::finalize_into``
 
 ## 0.9.2 2023-02-24
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 - Add more Wycheproof tests
 - Add support for loading DSA public and private keys using
   ``Pubkey::load_dsa`` and ``Privkey::load_dsa``
+- Add support for loading ElGamal public and private keys using
+  ``Pubkey::load_elgamal`` and ``Privkey::load_elgamal``
 
 ## 0.9.2 2023-02-24
 

--- a/botan/src/cipher.rs
+++ b/botan/src/cipher.rs
@@ -230,8 +230,34 @@ impl Cipher {
 
     /// incremental update
     fn _update(&mut self, msg: &[u8], end: bool) -> Result<Vec<u8>> {
-        let flags = u32::from(end);
         let mut output = vec![0; msg.len() + if end { self.tag_length() } else { 0 }];
+        let output_written = self._update_into(msg, end, &mut output)?;
+        output.resize(output_written, 0);
+        Ok(output)
+    }
+
+    /// incremental update, writing to provided buffer
+    ///
+    /// Returns the number of bytes written to `output`.
+    fn _update_into(&mut self, msg: &[u8], end: bool, output: &mut [u8]) -> Result<usize> {
+        let expected_len = match (self.direction, end) {
+            (CipherDirection::Encrypt, false) | (CipherDirection::Decrypt, false) => msg.len(),
+            (CipherDirection::Encrypt, true) => msg.len() + self.tag_length(),
+            (CipherDirection::Decrypt, true) => msg.len().saturating_sub(self.tag_length()),
+        };
+
+        if output.len() < expected_len {
+            return Err(Error::with_message(
+                ErrorType::BadParameter,
+                format!(
+                    "Provided output buffer has length {}, but expected at least {}",
+                    output.len(),
+                    expected_len
+                ),
+            ));
+        }
+
+        let flags = u32::from(end);
         let mut output_written = 0;
         let mut input_consumed = 0;
 
@@ -250,9 +276,7 @@ impl Cipher {
         assert_eq!(input_consumed, msg.len());
         assert!(output_written <= output.len());
 
-        output.resize(output_written, 0);
-
-        Ok(output)
+        Ok(output_written)
     }
 
     /// incremental update
@@ -273,6 +297,28 @@ impl Cipher {
         self._update(msg, false)
     }
 
+    /// incremental update writing into the given buffer
+    ///
+    /// The length of `output` has to be at least `msg.len()`.
+    /// Returns the number of bytes written to `output`.
+    ///
+    /// # Examples
+    /// ```
+    /// let mut aes_gcm = botan::Cipher::new("AES-128/GCM", botan::CipherDirection::Encrypt).unwrap();
+    /// aes_gcm.set_key(&vec![0; 16]).unwrap();
+    /// let nonce = vec![0; aes_gcm.default_nonce_length()];
+    /// let msg = vec![0; 96];
+    /// aes_gcm.start(&nonce).unwrap();
+    /// let mut ctext = vec![0; msg.len() + aes_gcm.tag_length()];
+    /// let mut written = 0;
+    /// written += aes_gcm.update_into(&msg[..64], &mut ctext[written..]).unwrap();
+    /// written += aes_gcm.finish_into(&msg[64..], &mut ctext[written..]).unwrap();
+    /// assert_eq!(written, msg.len() + aes_gcm.tag_length());
+    /// ```
+    pub fn update_into(&mut self, msg: &[u8], output: &mut [u8]) -> Result<usize> {
+        self._update_into(msg, false, output)
+    }
+
     /// finish function
     ///
     /// # Examples
@@ -287,6 +333,28 @@ impl Cipher {
     /// ```
     pub fn finish(&mut self, msg: &[u8]) -> Result<Vec<u8>> {
         self._update(msg, true)
+    }
+
+    /// finish function writing into the given buffer
+    ///
+    /// The length of `output` has to be at least `msg.len() -
+    /// self.tag_length()` for decryption, and `msg.len() +
+    /// self.tag_length()` for encryption.  Returns the number of
+    /// bytes written to `output`.
+    ///
+    /// # Examples
+    /// ```
+    /// let mut aes_gcm = botan::Cipher::new("AES-128/GCM", botan::CipherDirection::Encrypt).unwrap();
+    /// aes_gcm.set_key(&vec![0; 16]).unwrap();
+    /// let nonce = vec![0; aes_gcm.default_nonce_length()];
+    /// let msg = vec![0; 96];
+    /// aes_gcm.start(&nonce).unwrap();
+    /// let mut ctext = vec![0; msg.len() + aes_gcm.tag_length()];
+    /// let written = aes_gcm.finish_into(&msg, &mut ctext[..]).unwrap();
+    /// assert_eq!(written, msg.len() + aes_gcm.tag_length());
+    /// ```
+    pub fn finish_into(&mut self, msg: &[u8], output: &mut [u8]) -> Result<usize> {
+        self._update_into(msg, true, output)
     }
 
     /// Clear all state associated with the key

--- a/botan/src/cipher.rs
+++ b/botan/src/cipher.rs
@@ -216,7 +216,6 @@ impl Cipher {
         botan_call!(botan_cipher_start, self.obj, nonce.as_ptr(), nonce.len())
     }
 
-    /// Encrypt or decrypt a message with the provided nonce. The key must
     /// incremental update
     fn _update(&mut self, msg: &[u8], end: bool) -> Result<Vec<u8>> {
         let flags = u32::from(end);

--- a/botan/src/pubkey.rs
+++ b/botan/src/pubkey.rs
@@ -111,6 +111,17 @@ impl Privkey {
         Ok(Privkey { obj })
     }
 
+    /// Load an ElGamal private key (p,g,x)
+    pub fn load_elgamal(p: &MPI, g: &MPI, x: &MPI) -> Result<Privkey> {
+        let obj = botan_init!(
+            botan_privkey_load_elgamal,
+            p.handle(),
+            g.handle(),
+            x.handle()
+        )?;
+        Ok(Privkey { obj })
+    }
+
     /// Load an ECDSA private key with specified curve and secret scalar
     pub fn load_ecdsa(s: &MPI, curve_name: &str) -> Result<Privkey> {
         let curve_name = make_cstr(curve_name)?;
@@ -431,6 +442,17 @@ impl Pubkey {
             botan_pubkey_load_dsa,
             p.handle(),
             q.handle(),
+            g.handle(),
+            y.handle()
+        )?;
+        Ok(Pubkey { obj })
+    }
+
+    /// Load an ElGamal public key (p,g,y)
+    pub fn load_elgamal(p: &MPI, g: &MPI, y: &MPI) -> Result<Pubkey> {
+        let obj = botan_init!(
+            botan_pubkey_load_elgamal,
+            p.handle(),
             g.handle(),
             y.handle()
         )?;

--- a/botan/src/pubkey.rs
+++ b/botan/src/pubkey.rs
@@ -99,6 +99,18 @@ impl Privkey {
         Ok(Privkey { obj })
     }
 
+    /// Load an DSA private key (p,q,g,x)
+    pub fn load_dsa(p: &MPI, q: &MPI, g: &MPI, x: &MPI) -> Result<Privkey> {
+        let obj = botan_init!(
+            botan_privkey_load_dsa,
+            p.handle(),
+            q.handle(),
+            g.handle(),
+            x.handle()
+        )?;
+        Ok(Privkey { obj })
+    }
+
     /// Load an ECDSA private key with specified curve and secret scalar
     pub fn load_ecdsa(s: &MPI, curve_name: &str) -> Result<Privkey> {
         let curve_name = make_cstr(curve_name)?;
@@ -410,6 +422,18 @@ impl Pubkey {
     /// Load an DH public key (p,g,y)
     pub fn load_dh(p: &MPI, g: &MPI, y: &MPI) -> Result<Pubkey> {
         let obj = botan_init!(botan_pubkey_load_dh, p.handle(), g.handle(), y.handle())?;
+        Ok(Pubkey { obj })
+    }
+
+    /// Load an DSA public key (p,q,g,y)
+    pub fn load_dsa(p: &MPI, q: &MPI, g: &MPI, y: &MPI) -> Result<Pubkey> {
+        let obj = botan_init!(
+            botan_pubkey_load_dsa,
+            p.handle(),
+            q.handle(),
+            g.handle(),
+            y.handle()
+        )?;
         Ok(Pubkey { obj })
     }
 


### PR DESCRIPTION
While porting Sequoia-PGP to Botan, I had to amend the bindings a little.

Work in progress backend: https://gitlab.com/sequoia-pgp/sequoia/-/commit/11ca5a66a257202179642b7e361eb9e6f3fbb754

The first two commits add support for loading DSA and ElGamal keys, respectively.  The last commit adds an interface to `Cipher` that allows decryption and encryption without returning the result as a `Vec<u8>`.

Thanks for your consideration!