### PR TITLE
Use std::os::raw types on std builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,9 @@ jobs:
             features: botan3
           - toolchain: stable
             features: vendored
-          - toolchain: 1.64.0 # MSRV
+          - toolchain: 1.64.0 # no-std MSRV
+            features: no-std
+          - toolchain: 1.58.0 # MSRV
           - toolchain: nightly
           - toolchain: nightly
             features: no-std

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,9 @@
 
+## 0.10.1 Not Yet Released
+
+- The MSRV for std builds has been reduced to Rust 1.58. The MSRV for
+  no-std builds remains Rust 1.64
+
 ## 0.10.0 2023-03-07
 
 - Add support for new Botan 3 APIs including zfec forward error correction,

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 This crate wraps the C API exposed by the [Botan](https://botan.randombit.net/)
 cryptography library. The current version requires Botan 2.8.0 or higher
-and Rust 1.64.0 or higher.
+and Rust 1.58.0 or higher.
 
 The following features are supported:
 
-* `no-std`: Enable a no-std build (`alloc` support is required)
+* `no-std`: Enable a no-std build. This requires Rust 1.64.0 or higher.
 * `vendored`: Build a copy of the C++ library directly, without
   relying on a system installed version.
 * `botan3`: Link against (the currently unreleased) Botan 3.x rather

--- a/botan-sys/Cargo.toml
+++ b/botan-sys/Cargo.toml
@@ -12,6 +12,7 @@ documentation = "https://docs.rs/botan-sys"
 readme = "README.md"
 categories = [ "cryptography", "external-ffi-bindings", "no-std" ]
 edition = "2021"
+rust-version = "1.58"
 
 [features]
 default = []

--- a/botan-sys/src/lib.rs
+++ b/botan-sys/src/lib.rs
@@ -25,7 +25,7 @@ pub mod ffi_types {
     pub use core::ffi::{c_char, c_int, c_uint, c_void};
 
     #[cfg(not(feature = "no-std"))]
-    pub use std::ffi::{c_char, c_int, c_uint, c_void};
+    pub use std::os::raw::{c_char, c_int, c_uint, c_void};
 }
 
 pub use block::*;

--- a/botan/Cargo.toml
+++ b/botan/Cargo.toml
@@ -11,6 +11,7 @@ keywords = [ "crypto" ]
 readme = "../README.md"
 categories = [ "cryptography", "api-bindings", "no-std" ]
 edition = "2021"
+rust-version = "1.58"
 
 [dependencies]
 botan-sys = { version = "0.10.0", path = "../botan-sys" }


### PR DESCRIPTION
This reduces MSRV to 1.58.0 for std builds