### PR TITLE
Exclude uploading the tests to crates.io

### DIFF
--- a/botan-src/Cargo.toml
+++ b/botan-src/Cargo.toml
@@ -9,6 +9,12 @@ homepage = "https://botan.randombit.net/"
 repository = "https://github.com/randombit/botan-rs"
 readme = "README.md"
 categories = ["cryptography"]
+exclude = ["botan/doc",
+           "botan/src/cli",
+           "botan/src/tests",
+           "botan/src/bogo_shim",
+           "botan/src/examples",
+           "botan/src/fuzzer"]
 
 [dependencies]
 


### PR DESCRIPTION
We don't run the tests anyway, and this improves the package size