### PR TITLE
Use `std` feature instead of `no_std` (#92)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 ## 0.11.0 Not Yet Released
 
 - Bump MSRV to 1.64.0 for both std and no-std builds
+- The `no-std` feature has been replaced by a `std` feature;
+  use `no-default-features` to request a no_std enabled build.
 
 ## 0.10.7 2023-10-05
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ Features
 
 The following features are supported:
 
-* `no-std`: Enable a no-std build. This requires Rust 1.64.0 or higher,
-  as well as `alloc` support
+* `std` (enabled by default): Enable using std library. If disabled
+  (resulting in a `no_std` build), then Rust 1.64.0 or higher is
+  required.
 * `vendored`: Build a copy of the C++ library directly, without
   relying on a system installed version.
 * `botan3`: Enable support for using APIs added in Botan 3.

--- a/botan/Cargo.toml
+++ b/botan/Cargo.toml
@@ -21,7 +21,7 @@ wycheproof = "0.5"
 hex = "0.4"
 
 [features]
-default = []
-no-std = []
+default = ["std"]
+std = []
 vendored = ["botan-sys/vendored"]
 botan3 = ["botan-sys/botan3"]

--- a/botan/src/lib.rs
+++ b/botan/src/lib.rs
@@ -3,9 +3,9 @@
 
 //! A wrapper for the Botan cryptography library
 
-#![cfg_attr(feature = "no-std", no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(feature = "no-std")]
+#[cfg(not(feature = "std"))]
 #[macro_use]
 extern crate alloc;
 

--- a/botan/src/utils.rs
+++ b/botan/src/utils.rs
@@ -1,16 +1,16 @@
 use botan_sys::*;
 use core::fmt;
 
-#[cfg(feature = "no-std")]
+#[cfg(not(feature = "std"))]
 pub(crate) use alloc::{borrow::ToOwned, string::String, string::ToString, vec::Vec};
 
-#[cfg(feature = "no-std")]
+#[cfg(not(feature = "std"))]
 pub(crate) use alloc::ffi::CString;
 
-#[cfg(feature = "no-std")]
+#[cfg(not(feature = "std"))]
 pub(crate) use core::ffi::CStr;
 
-#[cfg(not(feature = "no-std"))]
+#[cfg(feature = "std")]
 pub(crate) use std::ffi::{CStr, CString};
 
 pub(crate) use botan_sys::ffi_types::{c_char, c_int, c_void};
@@ -202,7 +202,7 @@ impl Error {
         }
     }
 
-    #[cfg(not(feature = "no-std"))]
+    #[cfg(feature = "std")]
     pub(crate) fn conversion_error<T: std::error::Error>(e: T) -> Self {
         Self {
             err_type: ErrorType::ConversionError,
@@ -211,7 +211,7 @@ impl Error {
     }
 
     // Hack to deal with missing std::error::Error in no-std
-    #[cfg(feature = "no-std")]
+    #[cfg(not(feature = "std"))]
     pub(crate) fn conversion_error<T: core::fmt::Display>(e: T) -> Self {
         Self {
             err_type: ErrorType::ConversionError,
@@ -312,7 +312,7 @@ impl fmt::Display for ErrorType {
     }
 }
 
-#[cfg(not(feature = "no-std"))]
+#[cfg(feature = "std")]
 impl std::error::Error for Error {}
 
 impl From<i32> for ErrorType {


### PR DESCRIPTION
This is technically a SemVer break so I'm not sure if this should wait until we're doing some other SemVer bump, or what.