### PR TITLE
Allow construction of DER-encoded signatures

### DIFF
--- a/botan/src/pk_ops.rs
+++ b/botan/src/pk_ops.rs
@@ -40,6 +40,19 @@ impl Signer {
         Ok(Signer { obj, sig_len })
     }
 
+    /// Create a new signature operator that outputs DER-formatted signatures
+    pub fn new_with_der_formatted_signatures(key: &Privkey, padding: &str) -> Result<Signer> {
+        let padding = make_cstr(padding)?;
+        let obj = botan_init!(
+            botan_pk_op_sign_create,
+            key.handle(),
+            padding.as_ptr(),
+            1u32
+        )?;
+        let sig_len = botan_usize!(botan_pk_op_sign_output_length, obj)?;
+        Ok(Signer { obj, sig_len })
+    }
+
     /// Add more bytes of the message that will be signed
     pub fn update(&mut self, data: &[u8]) -> Result<()> {
         botan_call!(botan_pk_op_sign_update, self.obj, data.as_ptr(), data.len())

--- a/botan/tests/tests.rs
+++ b/botan/tests/tests.rs
@@ -771,6 +771,47 @@ fn test_pubkey_sign() -> Result<(), botan::Error> {
 }
 
 #[test]
+fn test_pubkey_sign_der() -> Result<(), botan::Error> {
+    let msg = vec![1, 23, 42];
+
+    let mut rng = botan::RandomNumberGenerator::new_system()?;
+
+    let ecdsa_key = botan::Privkey::create("ECDSA", "secp256r1", &mut rng)?;
+    assert!(ecdsa_key.key_agreement_key().is_err());
+
+    let mut signer = botan::Signer::new_with_der_formatted_signatures(&ecdsa_key, "SHA-256")?;
+    signer.update(&msg)?;
+    let signature = signer.finish(&mut rng)?;
+
+    let pub_key = ecdsa_key.pubkey()?;
+
+    let mut verifier = botan::Verifier::new_with_der_formatted_signatures(&pub_key, "SHA-256")?;
+
+    verifier.update(&[1])?;
+    verifier.update(&[23, 42])?;
+
+    assert!(verifier.finish(&signature)?);
+
+    verifier.update(&[1])?;
+    assert!(!(verifier.finish(&signature)?));
+
+    verifier.update(&[1])?;
+    verifier.update(&[23, 42])?;
+
+    assert!(verifier.finish(&signature)?);
+
+    // DER Signatures start with a SEQUENCE
+    assert_eq!(signature[0], 0x30);
+
+    // The SEQUENCE contains the whole signature (for ECDSA w/ secp256r1, the length can always be encoded with a single byte)
+    assert_eq!(signature[1], (signature.len() - 2) as u8);
+
+    // The first element is an INTEGER
+    assert_eq!(signature[2], 0x02);
+    Ok(())
+}
+
+#[test]
 fn test_pubkey_encrypt() -> Result<(), botan::Error> {
     let msg = vec![1, 23, 42];
 


### PR DESCRIPTION
While the `Verifier` exposes a constructor that allows to verify DER-encoded signatures, there is no way to construct them.

This adds a `new_with_der_formatted_signatures` constructor to `Signer`, similar to the one in `Verifier`.