### PR TITLE
Add getters for X.509 certificate notBefore and notAfter fields

### DIFF
--- a/botan-sys/src/x509.rs
+++ b/botan-sys/src/x509.rs
@@ -53,6 +53,8 @@ extern "C" {
         out: *mut c_char,
         out_len: *mut usize,
     ) -> c_int;
+    pub fn botan_x509_cert_not_before(cert: botan_x509_cert_t, timestamp: *mut u64) -> c_int;
+    pub fn botan_x509_cert_not_after(cert: botan_x509_cert_t, timestamp: *mut u64) -> c_int;
     pub fn botan_x509_cert_get_fingerprint(
         cert: botan_x509_cert_t,
         hash: *const c_char,

--- a/botan/src/x509_cert.rs
+++ b/botan/src/x509_cert.rs
@@ -176,6 +176,42 @@ impl Certificate {
         })
     }
 
+    /// Return the certificate notBefore time in seconds since epoch
+    pub fn not_before_raw(&self) -> Result<u64> {
+        let mut timestamp = 0u64;
+        let rc = unsafe { botan_x509_cert_not_before(self.obj, &mut timestamp) };
+        if rc != 0 {
+            Err(Error::from_rc(rc))
+        } else {
+            Ok(timestamp)
+        }
+    }
+
+    /// Return the certificate notAfter time in seconds since epoch
+    pub fn not_after_raw(&self) -> Result<u64> {
+        let mut timestamp = 0u64;
+        let rc = unsafe { botan_x509_cert_not_after(self.obj, &mut timestamp) };
+        if rc != 0 {
+            Err(Error::from_rc(rc))
+        } else {
+            Ok(timestamp)
+        }
+    }
+
+    #[cfg(feature = "std")]
+    /// Return the certificate notBefore time as a SystemTime
+    pub fn not_before(&self) -> Result<std::time::SystemTime> {
+        use std::time::{Duration, UNIX_EPOCH};
+        Ok(UNIX_EPOCH + Duration::from_secs(self.not_before_raw()?))
+    }
+
+    #[cfg(feature = "std")]
+    /// Return the certificate notBefore time as a SystemTime
+    pub fn not_after(&self) -> Result<std::time::SystemTime> {
+        use std::time::{Duration, UNIX_EPOCH};
+        Ok(UNIX_EPOCH + Duration::from_secs(self.not_after_raw()?))
+    }
+
     /// Return the byte representation of the public key
     pub fn public_key_bits(&self) -> Result<Vec<u8>> {
         #[cfg(not(feature = "botan3"))]

--- a/botan/tests/tests.rs
+++ b/botan/tests/tests.rs
@@ -466,6 +466,21 @@ fn test_certs() -> Result<(), botan::Error> {
     assert_eq!(cert.authority_key_id()?, key_id);
     assert_eq!(cert.subject_key_id()?, key_id);
 
+    assert_eq!(cert.not_before_raw()?, 1184858838);
+    assert_eq!(cert.not_after_raw()?, 1831907880);
+
+    #[cfg(feature = "std")]
+    {
+        assert_eq!(
+            cert.not_before()?,
+            std::time::UNIX_EPOCH + std::time::Duration::from_secs(1184858838)
+        );
+        assert_eq!(
+            cert.not_after()?,
+            std::time::UNIX_EPOCH + std::time::Duration::from_secs(1831907880)
+        );
+    }
+
     assert!(cert.allows_usage(botan::CertUsage::CertificateSign)?);
     assert!(cert.allows_usage(botan::CertUsage::CrlSign)?);
     assert!(!(cert.allows_usage(botan::CertUsage::KeyEncipherment)?));


### PR DESCRIPTION
Related GH #131