### PR TITLE
Remove fips140 module prior to crates.io publication

### DIFF
--- a/botan-src/Cargo.toml
+++ b/botan-src/Cargo.toml
@@ -13,6 +13,7 @@ rust-version = "1.64"
 
 exclude = ["botan/doc",
            "botan/src/bogo_shim",
+           "botan/src/build-data/policy/fips140.txt", # TODO remove this for 3.8.0
            "botan/src/cli",
            "botan/src/ct_selftest",
            "botan/src/examples",


### PR DESCRIPTION
There are some unfortunate interactions here.

This is fixed in a more complete way in upstream 3.8.0 and crate 0.12, both scheduled for early May.

#144 