### PR TITLE
Fix exclusion of tls and sodium subdirs for publication

### DIFF
--- a/botan-src/Cargo.toml
+++ b/botan-src/Cargo.toml
@@ -17,10 +17,12 @@ exclude = ["botan/doc",
            "botan/src/ct_selftest",
            "botan/src/examples",
            "botan/src/fuzzer",
+           "botan/src/lib/compat/sodium",
            "botan/src/lib/filters",
            "botan/src/lib/prov/pkcs11",
            "botan/src/lib/prov/tpm",
            "botan/src/lib/prov/tpm2",
+           "botan/src/lib/tls",
            "botan/src/python",
            "botan/src/tests"]
 


### PR DESCRIPTION
The change in #162 just deleted the commmented out lines rather than *enabling* the exclusion...