### PR TITLE
Implement rand::TryRngCore for RandomNumberGenerator

### DIFF
--- a/botan/Cargo.toml
+++ b/botan/Cargo.toml
@@ -15,17 +15,19 @@ rust-version = "1.64"
 
 [dependencies]
 botan-sys = { version = "1.20250506", path = "../botan-sys" }
+rand = { version = "0.9.2", default-features = false, optional = true }
 
 [dev-dependencies]
 wycheproof = { version = "0.6", default-features = false, features = ["aead", "cipher", "dsa", "ecdh", "ecdsa", "eddsa", "hkdf", "keywrap", "mac", "primality", "rsa_enc", "rsa_sig", "xdh"] }
 hex = "0.4"
 
 [features]
-default = ["std"]
+default = ["std", "rand"]
 std = []
 vendored = ["botan-sys/vendored"]
 static = ["botan-sys/static"]
 pkg-config = ["botan-sys/pkg-config"]
+rand = ["dep:rand"]
 
 [lints.clippy]
 # introduced because of from_str

--- a/botan/src/rng.rs
+++ b/botan/src/rng.rs
@@ -164,3 +164,28 @@ impl RandomNumberGenerator {
         botan_call!(botan_rng_add_entropy, self.obj, seed.as_ptr(), seed.len())
     }
 }
+
+#[cfg(feature = "rand")]
+impl rand::TryRngCore for RandomNumberGenerator {
+    type Error = Error;
+
+    fn try_next_u32(&mut self) -> Result<u32> {
+        let mut bytes: [u8; 4] = [0; 4];
+        self.fill(&mut bytes)?;
+        Ok(u32::from_be_bytes(bytes))
+    }
+
+    fn try_next_u64(&mut self) -> Result<u64> {
+        let mut bytes: [u8; 8] = [0; 8];
+        self.fill(&mut bytes)?;
+        Ok(u64::from_be_bytes(bytes))
+    }
+
+    fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<()> {
+        self.fill(dst)?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "rand")]
+impl rand::TryCryptoRng for RandomNumberGenerator {}

--- a/botan/tests/tests.rs
+++ b/botan/tests/tests.rs
@@ -408,6 +408,23 @@ fn test_rng() -> Result<(), botan::Error> {
     let read2 = rng.read(10)?;
 
     assert!(read1 != read2);
+
+    #[cfg(feature = "rand")]
+    {
+        use rand::TryRngCore;
+
+        let read1 = rng.try_next_u32()?;
+        let read2 = rng.try_next_u32()?;
+        assert!(read1 != read2);
+
+        let read1 = rng.try_next_u64()?;
+        let read2 = rng.try_next_u64()?;
+        assert!(read1 != read2);
+
+        let mut bytes = vec![0; 64];
+        rng.try_fill_bytes(&mut bytes)?;
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
Allows using `RandomNumberGenerator` in things that require `rand::Rng` (by wrapping with `rand_core::UnwrapErr()`).
```rs
use botan::RandomNumberGenerator;
use rand::seq::{rand_core, SliceRandom};

let mut v = vec![1, 2, 3, 4, 5];
v.shuffle(&mut rand::rand_core::UnwrapErr(
    RandomNumberGenerator::new_system()?,
));
println!("{:?}", v);
```