### PR TITLE
Fix BOTAN_INCLUDE_DIR usage

### DIFF
--- a/botan-sys/build/main.rs
+++ b/botan-sys/build/main.rs
@@ -174,11 +174,25 @@ fn find_botan_include_dir() -> std::path::PathBuf {
 
     #[cfg(not(feature = "pkg-config"))]
     {
-        if let Some(dir) = env_var("BOTAN_INCLUDE_DIR") {
-            return dir.into();
+        fn find_in_basedir(basedir: PathBuf) -> Option<PathBuf> {
+            for major_version in [3, 2] {
+                let dir = PathBuf::from(format!("botan-{major_version}"));
+                let inc_dir = basedir.join(dir.clone());
+                if inc_dir.exists() {
+                    return Some(inc_dir);
+                }
+            }
+            None
         }
 
-        fn possible_header_locations() -> Vec<std::path::PathBuf> {
+        if let Some(dir) = env_var("BOTAN_INCLUDE_DIR") {
+            let Some(dir) = find_in_basedir(dir.into()) else {
+                panic!("BOTAN_INCLUDE_DIR does not point to a valid location");
+            };
+            return dir;
+        }
+
+        fn possible_header_locations() -> Vec<PathBuf> {
             let dirs = [
                 "/opt/homebrew/include",
                 "/usr/local/include",
@@ -197,13 +211,9 @@ fn find_botan_include_dir() -> std::path::PathBuf {
             paths
         }
 
-        for major_version in [3, 2] {
-            let dir = PathBuf::from(format!("botan-{major_version}"));
-            for basedir in possible_header_locations() {
-                let inc_dir = basedir.join(dir.clone());
-                if inc_dir.exists() {
-                    return inc_dir;
-                }
+        for basedir in possible_header_locations() {
+            if let Some(dir) = find_in_basedir(basedir) {
+                return dir;
             }
         }
 


### PR DESCRIPTION
The readme in `botan-sys` suggests that if botan headers can be found in `foo/botan-3/botan`, `BOTAN_INCLUDE_DIR` should only be set to `foo/`, implying that the `botan-3/botan` path will be added by the build system.
Currently, for the default search paths, the `botan-{major-version}` suffix is appended to the basepath, but not to `BOTAN_INCLUDE_DIR` if it is set, i.e. it would need to be set to `foo/botan-3`, which does not adhere to the readme.

I've provided a draft implementation that searches in `BOTAN_INCLUDE_DIR/botan-{3,2}` just like it does for the default paths.

That however would prohibit the user to provide things such as `foo/botan/` for the `BOTAN_INCLUDE_DIR`, where the headers are directly contained in `foo/botan/`, so the simpler fix could just be to update the readme :)