### PR TITLE
Upgrade rand dependency to v10

### DIFF
--- a/botan/Cargo.toml
+++ b/botan/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.85"
 
 [dependencies]
 botan-sys = { version = "1.20260811", path = "../botan-sys" }
-rand = { version = "0.9.2", default-features = false, optional = true }
+rand_core = { version = "0.10", default-features = false, optional = true }
 
 [dev-dependencies]
 wycheproof = { version = "0.6", default-features = false, features = ["aead", "cipher", "dsa", "ecdh", "ecdsa", "eddsa", "hkdf", "keywrap", "mac", "primality", "rsa_enc", "rsa_sig", "xdh"] }
@@ -27,7 +27,7 @@ std = []
 vendored = ["botan-sys/vendored"]
 static = ["botan-sys/static"]
 pkg-config = ["botan-sys/pkg-config"]
-rand = ["dep:rand"]
+rand = ["dep:rand_core"]
 
 [lints.clippy]
 # introduced because of from_str

--- a/botan/src/rng.rs
+++ b/botan/src/rng.rs
@@ -166,7 +166,7 @@ impl RandomNumberGenerator {
 }
 
 #[cfg(feature = "rand")]
-impl rand::TryRngCore for RandomNumberGenerator {
+impl rand_core::TryRng for RandomNumberGenerator {
     type Error = Error;
 
     fn try_next_u32(&mut self) -> Result<u32> {
@@ -188,4 +188,4 @@ impl rand::TryRngCore for RandomNumberGenerator {
 }
 
 #[cfg(feature = "rand")]
-impl rand::TryCryptoRng for RandomNumberGenerator {}
+impl rand_core::TryCryptoRng for RandomNumberGenerator {}

--- a/botan/tests/tests.rs
+++ b/botan/tests/tests.rs
@@ -488,7 +488,7 @@ fn test_rng() -> Result<(), botan::Error> {
 
     #[cfg(feature = "rand")]
     {
-        use rand::TryRngCore;
+        use rand_core::TryRng;
 
         let read1 = rng.try_next_u32()?;
         let read2 = rng.try_next_u32()?;


### PR DESCRIPTION
MSRV is already at 1.85 as discussed in #170, so actually bump.
Also switches from `rand` to `rand_core` to pull in fewer unneeded dependencies (`rand` just reexports the traits from `rand_core`)