### PR TITLE
Support loading libbotan at runtime instead of using static linking

### DIFF
--- a/.ci/build.py
+++ b/.ci/build.py
@@ -24,6 +24,9 @@ def compute_features(features, for_who):
     if 'vendored' in features:
         feat.append('vendored')
 
+    if 'dynamic' in features:
+        feat.append('dynamic-loading')
+
     if for_who == 'lib' and 'no-std' not in features:
         feat.append('std')
 
@@ -63,7 +66,7 @@ def main(args = None):
             os.environ["SCCACHE_MAXSIZE"] = "2G"
 
     KNOWN_TOOLCHAINS = ['stable', 'nightly', '1.85.1']
-    KNOWN_FEATURES = ['vendored', 'git', 'no-std', 'minimized']
+    KNOWN_FEATURES = ['vendored', 'git', 'no-std', 'minimized', 'dynamic']
 
     toolchain = args[1]
 
@@ -99,6 +102,14 @@ def main(args = None):
 
     if 'vendored' in features and 'git' in features:
         print("ERROR: Incompatible features vendored and git")
+        return 1
+
+    if 'dynamic' in features and 'vendored' in features:
+        print("ERROR: Incompatible features dynamic and vendored")
+        return 1
+
+    if 'dynamic' in features and 'no-std' in features:
+        print("ERROR: Feature dynamic requires std")
         return 1
 
     if 'minimized' in features and 'git' not in features:
@@ -149,7 +160,13 @@ def main(args = None):
         os.environ["RUSTDOCFLAGS"] = "-D warnings -L/opt/homebrew/lib"
         os.environ["DYLD_LIBRARY_PATH"] = homebrew_dir
     elif os.access('/usr/bin/apt-get', os.R_OK):
-        run_command(['sudo', 'apt-get', 'install', 'libbotan-2-dev'])
+        if 'dynamic' in features:
+            # With dynamic loading no headers are needed to build, and the
+            # library is located at runtime; install only the runtime package
+            # to verify this
+            run_command(['sudo', 'apt-get', 'install', 'libbotan-2-19'])
+        else:
+            run_command(['sudo', 'apt-get', 'install', 'libbotan-2-dev'])
 
     run_command(['rustc', '--version'])
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
 
       - run: ./botan-src/scripts/fetch.py
       - run: cargo +nightly clippy --all-targets -- --deny warnings
+      - run: cargo +nightly clippy --all-targets --features dynamic-loading -- --deny warnings
   ci:
     runs-on: ubuntu-24.04
 
@@ -53,9 +54,15 @@ jobs:
             features: git+minimized
           - toolchain: stable
             features: vendored
+          - toolchain: stable
+            features: dynamic
+          - toolchain: stable
+            features: dynamic+git
           - toolchain: 1.85.1 # MSRV no-std
             features: no-std+git
           - toolchain: 1.85.1 # MSRV
+          - toolchain: 1.85.1 # MSRV dynamic loading
+            features: dynamic
           - toolchain: nightly
           - toolchain: nightly
             features: no-std+git
@@ -90,6 +97,8 @@ jobs:
           - toolchain: stable
           - toolchain: stable
             features: git
+          - toolchain: stable
+            features: dynamic
           - toolchain: nightly
 
     steps:
@@ -122,6 +131,8 @@ jobs:
           - toolchain: stable
           - toolchain: stable
             features: vendored
+          - toolchain: stable
+            features: dynamic
           - toolchain: nightly
 
     steps:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,14 @@
 ## 0.14.0 Not Yet Released
 
 - Minor version bump due to changes to `ErrorType`
-
 - All APIs are available no matter what version of Botan the crate builds against.
   If an older library is in use, the API will fail with `NotImplemented`; the
   new `Error::is_function_unavailable` distinguishes this from functionality
   compiled out of the library.
+- Add the `dynamic-loading` feature, which loads the Botan shared library at
+  runtime rather than linking to it. No Botan installation is needed to build,
+  and the available functionality is determined by the library found at
+  runtime. See `botan::load_library`.
 - `ErrorType` is now `#[non_exhaustive]` and gains the `LibraryNotLoaded` variant
 - The `no_std` build no longer requires Botan 3.11.0 at build time; instead
   relevant public key operations return an error at runtime with older versions

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ The following features are supported:
   provided Botan dependency.
 * `pkg-config`: Enable finding a non-vendored, externally provided
   Botan with pkg-config. Can be used in combination with `static`.
+* `dynamic-loading`: Instead of linking to Botan at build time, load the
+  Botan shared library at runtime (using `dlopen`/`LoadLibrary`) and resolve
+  each function on first use. See below. Requires `std`, and cannot be
+  combined with `vendored` or `static`.
 
 Availability Of Newer APIs
 --------------------------
@@ -60,3 +64,18 @@ used to check the version of the library in use at runtime.
 When building against a system installed Botan, `botan-sys` detects at build
 time which functions the headers declare; functions the headers predate are
 replaced by stubs which return the error above.
+
+Dynamic Loading
+---------------
+
+With the `dynamic-loading` feature, no Botan installation is required to build
+the crate, and the resulting binary has no link time dependency on Botan.
+Instead the shared library (`libbotan-3.so.N`, `libbotan-3.dylib`,
+`botan-3.dll`, or the Botan 2 equivalents) is searched for and loaded the first
+time it is needed, or `botan::load_library` can be called first to specify
+exactly which library to use. Every FFI function is resolved on first use, so
+the set of available functionality is determined entirely by the library found
+at runtime: an application built against this crate can pick up newer Botan
+features simply by being run against a newer library, and continues to work
+(returning `NotImplemented` for newer features) against an older one. If no
+usable library can be found, operations fail with `ErrorType::LibraryNotLoaded`.

--- a/botan-sys/Cargo.toml
+++ b/botan-sys/Cargo.toml
@@ -19,6 +19,10 @@ default = []
 vendored = ["botan-src"]
 static = []
 pkg-config = ["dep:pkg-config"]
+dynamic-loading = ["dep:libloading"]
+
+[dependencies]
+libloading = { version = "0.8", optional = true }
 
 [build-dependencies]
 botan-src = { version = "0.31300.0", optional = true, path = "../botan-src" }

--- a/botan-sys/README.md
+++ b/botan-sys/README.md
@@ -7,13 +7,16 @@ for linking to it.
 A high level Rust interface built on these declarations is included in the
 [botan](https://crates.io/crates/botan) crate.
 
-This crate is always `no_std`
+This crate is `no_std` unless the `dynamic-loading` feature is used.
 
 ## Features
 
 * `vendored`: Build against the `botan-src` crate
 * `static`: Statically link the library. This is always used if `vendored` is set
 * `pkg-config`: Use `pkg-config` instead of probing to find the library
+* `dynamic-loading`: Do not link to Botan; instead load the shared library at
+  runtime and resolve each function on first use. Requires `std`, and cannot
+  be combined with `vendored` or `static`. See `botan_sys::load_library`.
 
 ## Availability of functions
 
@@ -29,6 +32,12 @@ present, and handle unavailable functionality at runtime.
 Internally the crate detects which version of the FFI interface the headers
 declare and enables `#[cfg(botan_ffi_YYYYMMDD)]` for each supported version;
 these cfgs are not visible to dependent crates.
+
+With the `dynamic-loading` feature there is no build time detection at all;
+each function is a wrapper which resolves the symbol from the loaded library
+on first use, returning `BOTAN_FFI_ERROR_FUNCTION_NOT_AVAILABLE` if the
+library does not export it, or `BOTAN_FFI_ERROR_LIBRARY_NOT_LOADED` if no
+library could be loaded.
 
 ## Environment Variables
 

--- a/botan-sys/build/main.rs
+++ b/botan-sys/build/main.rs
@@ -227,6 +227,12 @@ fn main() {
         println!("cargo:rustc-check-cfg=cfg(botan_ffi_{v})");
     }
 
+    // With dynamic loading nothing is linked and no headers are needed; the
+    // library is located and loaded at runtime.
+    if cfg!(feature = "dynamic-loading") {
+        return;
+    }
+
     #[cfg(feature = "vendored")]
     {
         let (lib_dir, inc_dir) = botan_src::build();

--- a/botan-sys/src/lib.rs
+++ b/botan-sys/src/lib.rs
@@ -2,8 +2,35 @@
 #![allow(non_camel_case_types)]
 #![allow(unused_imports)]
 
+//! FFI declarations for the Botan cryptography library
+//!
+//! By default (and with the `static` or `vendored` features) this crate links
+//! against the Botan library and detects at build time which functions the
+//! installed headers declare. Functions the headers predate are replaced by
+//! stubs returning [`BOTAN_FFI_ERROR_FUNCTION_NOT_AVAILABLE`].
+//!
+//! With the `dynamic-loading` feature the crate does not link against Botan;
+//! the shared library is loaded at runtime (see `load_library`) and every
+//! function is resolved on first use, so the set of available functions is
+//! determined entirely by the library found at runtime.
+
+#[cfg(feature = "dynamic-loading")]
+extern crate std;
+
+#[cfg(all(
+    feature = "dynamic-loading",
+    any(feature = "vendored", feature = "static")
+))]
+compile_error!("The dynamic-loading feature cannot be combined with vendored or static linking");
+
 #[macro_use]
 mod macros;
+
+#[cfg(feature = "dynamic-loading")]
+mod loader;
+
+#[cfg(feature = "dynamic-loading")]
+pub use loader::{LoadError, last_load_error, load_library, loaded_library_name};
 
 mod block;
 mod cipher;
@@ -72,6 +99,7 @@ pub use zfec::*;
 /// This is only ever `Some` when the `dynamic-loading` feature is enabled and
 /// loading the Botan shared library failed; in the linked build modes it
 /// always returns `None`.
+#[cfg(not(feature = "dynamic-loading"))]
 pub fn last_load_error() -> Option<&'static str> {
     None
 }

--- a/botan-sys/src/loader.rs
+++ b/botan-sys/src/loader.rs
@@ -1,0 +1,330 @@
+//! Runtime loading of the Botan shared library
+//!
+//! This module is only compiled when the `dynamic-loading` feature is
+//! enabled. In that mode the crate does not link against Botan at all;
+//! instead the shared library is loaded with `dlopen`/`LoadLibrary` the first
+//! time any FFI function is called (or when [`load_library`] is called
+//! explicitly), and each function is resolved lazily on first use.
+
+use std::boxed::Box;
+use std::ffi::OsStr;
+use std::fmt;
+use std::format;
+use std::string::{String, ToString};
+use std::sync::{Mutex, OnceLock};
+use std::vec::Vec;
+
+use libloading::Library;
+
+/// The oldest FFI API version this crate supports (Botan 2.13)
+const MINIMUM_FFI_VERSION: u32 = 20191214;
+
+/// The highest Botan 3 ABI revision (`libbotan-3.so.N`) that the default
+/// search will try. New releases are quarterly, and likely the release
+/// series stops around 3.17 with release of Botan4. At current pace 3.22
+/// would be in Q4 2028.
+const MAX_BOTAN3_ABI_REV: u32 = 22;
+
+/// An error which occurred while loading the Botan shared library
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum LoadError {
+    /// A Botan library has already been loaded, and cannot be replaced
+    AlreadyLoaded,
+    /// The library could not be loaded
+    LoadFailed(String),
+    /// A library was loaded, but it is not a usable version of Botan
+    UnusableLibrary(String),
+}
+
+impl fmt::Display for LoadError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::AlreadyLoaded => write!(f, "A Botan library has already been loaded"),
+            Self::LoadFailed(msg) => write!(f, "Unable to load the Botan library: {msg}"),
+            Self::UnusableLibrary(msg) => write!(f, "The loaded library is not usable: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for LoadError {}
+
+/// The reason a symbol could not be resolved
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Unavailable {
+    /// The library was loaded, but does not export the symbol
+    Function,
+    /// The library could not be loaded
+    Library,
+}
+
+/// A lazily resolved function from the loaded library
+///
+/// Each generated FFI wrapper owns one of these in a `static`; the symbol is
+/// looked up on first use and the result (including "not present") is
+/// cached for the lifetime of the process.
+pub(crate) struct Symbol<F: Copy + 'static> {
+    name: &'static str,
+    cell: OnceLock<Option<F>>,
+}
+
+impl<F: Copy + 'static> Symbol<F> {
+    /// Create a symbol; `name` must be NUL terminated
+    pub(crate) const fn new(name: &'static str) -> Self {
+        Self {
+            name,
+            cell: OnceLock::new(),
+        }
+    }
+
+    /// Resolve the symbol, loading the library first if necessary
+    ///
+    /// # Safety
+    ///
+    /// `F` must be the correct function pointer type for the symbol
+    pub(crate) unsafe fn get(&'static self) -> Result<F, Unavailable> {
+        let lib = library().map_err(|_| Unavailable::Library)?;
+        let sym = self.cell.get_or_init(|| {
+            // SAFETY: the caller guarantees F is the correct type; the library
+            // is stored in a static and never unloaded, so the raw function
+            // pointer remains valid for the life of the process
+            unsafe { lib.get::<F>(self.name.as_bytes()) }
+                .ok()
+                .map(|s| *s)
+        });
+        sym.ok_or(Unavailable::Function)
+    }
+}
+
+struct Loaded {
+    lib: Library,
+    name: String,
+}
+
+enum State {
+    /// The default search has not been attempted yet
+    Unattempted,
+    /// The default search was attempted and failed
+    AutoFailed(&'static str),
+}
+
+/// The loaded library. Once set it is never cleared or dropped, so function
+/// pointers resolved from it remain valid.
+static LIBRARY: OnceLock<Loaded> = OnceLock::new();
+
+/// Guards loading attempts, and remembers a failed default search so that it
+/// is not repeated on every call.
+static STATE: Mutex<State> = Mutex::new(State::Unattempted);
+
+fn lock_state() -> std::sync::MutexGuard<'static, State> {
+    STATE.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// Return the loaded library, performing the default search on first call
+fn library() -> Result<&'static Library, &'static str> {
+    if let Some(loaded) = LIBRARY.get() {
+        return Ok(&loaded.lib);
+    }
+
+    let mut state = lock_state();
+
+    // Another thread may have loaded it while we waited for the lock
+    if let Some(loaded) = LIBRARY.get() {
+        return Ok(&loaded.lib);
+    }
+
+    match *state {
+        State::AutoFailed(msg) => Err(msg),
+        State::Unattempted => match default_search() {
+            Ok(loaded) => {
+                let _ = LIBRARY.set(loaded);
+                Ok(&LIBRARY.get().expect("just set").lib)
+            }
+            Err(e) => {
+                let msg: &'static str = Box::leak(e.to_string().into_boxed_str());
+                *state = State::AutoFailed(msg);
+                Err(msg)
+            }
+        },
+    }
+}
+
+/// Open a shared library by name or path
+///
+/// # Safety
+///
+/// Loading a shared library runs its initialization code; this is inherent
+/// to dynamic loading.
+#[cfg(windows)]
+unsafe fn open_library(name: &OsStr) -> Result<Library, libloading::Error> {
+    use libloading::os::windows::{
+        LOAD_LIBRARY_SEARCH_DEFAULT_DIRS, LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR, Library as WinLibrary,
+    };
+
+    // The default LoadLibrary search order includes the current directory
+    // and PATH, which would allow a malicious DLL placed there to be loaded
+    // when searching by name. Restrict the search to the application
+    // directory, System32, and directories explicitly added with
+    // AddDllDirectory. When an absolute path is provided (via load_library)
+    // additionally allow the DLL's own directory, so that its dependencies
+    // located alongside it can be found.
+    let mut flags = LOAD_LIBRARY_SEARCH_DEFAULT_DIRS;
+    if std::path::Path::new(name).is_absolute() {
+        flags |= LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR;
+    }
+
+    unsafe { WinLibrary::load_with_flags(name, flags) }.map(Library::from)
+}
+
+/// Open a shared library by name or path
+///
+/// # Safety
+///
+/// Loading a shared library runs its initialization code; this is inherent
+/// to dynamic loading.
+#[cfg(not(windows))]
+unsafe fn open_library(name: &OsStr) -> Result<Library, libloading::Error> {
+    // dlopen searches the standard locations (rpath, LD_LIBRARY_PATH, the
+    // system cache and default directories) but not the current directory
+    unsafe { Library::new(name) }
+}
+
+/// Attempt to load the named library and verify that it is a usable Botan
+fn try_load(name: &OsStr) -> Result<Loaded, LoadError> {
+    // SAFETY: Botan's initialization code is benign
+    let lib = unsafe { open_library(name) }.map_err(|e| LoadError::LoadFailed(e.to_string()))?;
+
+    // SAFETY: this symbol has had this signature since the FFI was introduced
+    let api_version =
+        unsafe { lib.get::<unsafe extern "C" fn() -> u32>(b"botan_ffi_api_version\0") }.map_err(
+            |_| {
+                LoadError::UnusableLibrary(format!(
+                    "{} does not export botan_ffi_api_version",
+                    name.to_string_lossy()
+                ))
+            },
+        )?;
+
+    // SAFETY: calling the FFI function with its documented signature
+    let version = unsafe { api_version() };
+
+    if version < MINIMUM_FFI_VERSION {
+        return Err(LoadError::UnusableLibrary(format!(
+            "{} has FFI version {} but at least {} is required",
+            name.to_string_lossy(),
+            version,
+            MINIMUM_FFI_VERSION
+        )));
+    }
+
+    Ok(Loaded {
+        lib,
+        name: name.to_string_lossy().into_owned(),
+    })
+}
+
+/// The names tried by the default search, in order of preference
+fn candidate_names() -> Vec<String> {
+    let mut names = Vec::new();
+
+    if cfg!(target_os = "windows") {
+        names.push("botan-3.dll".to_string());
+        names.push("botan.dll".to_string()); // Botan 2.x
+    } else if cfg!(target_os = "macos") {
+        // Homebrew installs outside of the default dyld search path
+        let prefixes = ["", "/opt/homebrew/lib/", "/usr/local/lib/"];
+        for prefix in prefixes {
+            for rev in (0..=MAX_BOTAN3_ABI_REV).rev() {
+                names.push(format!("{prefix}libbotan-3.{rev}.dylib"));
+            }
+            names.push(format!("{prefix}libbotan-3.dylib"));
+        }
+        for prefix in prefixes {
+            for rev in (13..=19).rev() {
+                names.push(format!("{prefix}libbotan-2.{rev}.dylib"));
+            }
+            names.push(format!("{prefix}libbotan-2.dylib"));
+        }
+    } else {
+        // Botan 3.x: newest ABI revision first
+        for rev in (0..=MAX_BOTAN3_ABI_REV).rev() {
+            names.push(format!("libbotan-3.so.{rev}"));
+        }
+        names.push("libbotan-3.so".to_string());
+        // Botan 2.13 through 2.19
+        for rev in (13..=19).rev() {
+            names.push(format!("libbotan-2.so.{rev}"));
+        }
+        names.push("libbotan-2.so".to_string());
+    }
+
+    names
+}
+
+fn default_search() -> Result<Loaded, LoadError> {
+    let names = candidate_names();
+    let mut last_error = String::new();
+
+    for name in &names {
+        match try_load(OsStr::new(name)) {
+            Ok(loaded) => return Ok(loaded),
+            Err(LoadError::LoadFailed(msg) | LoadError::UnusableLibrary(msg)) => {
+                last_error = msg;
+            }
+            Err(e) => last_error = e.to_string(),
+        }
+    }
+
+    Err(LoadError::LoadFailed(format!(
+        "no Botan shared library found; tried {} names such as {} and {} (last error: {}). \
+         Use botan_sys::load_library to specify the location explicitly.",
+        names.len(),
+        names.first().map(String::as_str).unwrap_or(""),
+        names.last().map(String::as_str).unwrap_or(""),
+        last_error
+    )))
+}
+
+/// Load the Botan shared library from the specified path or name
+///
+/// This may be called before any other function in the crate is used, in
+/// order to control which library is loaded. If not called, the first FFI
+/// call performs a search for the library under its usual names.
+///
+/// The name is passed to `dlopen` (or `LoadLibrary`), so it may be either a
+/// bare filename which is searched for in the usual locations, or a full path.
+///
+/// Fails with `LoadError::AlreadyLoaded` if a library was already loaded, since
+/// the library cannot be replaced once functions have been resolved from it.
+pub fn load_library<P: AsRef<OsStr>>(path: P) -> Result<(), LoadError> {
+    let _state = lock_state();
+
+    if LIBRARY.get().is_some() {
+        return Err(LoadError::AlreadyLoaded);
+    }
+
+    let loaded = try_load(path.as_ref())?;
+    let _ = LIBRARY.set(loaded);
+    Ok(())
+}
+
+/// Return the name or path of the Botan shared library which was loaded
+///
+/// Returns `None` if no library has been loaded yet
+pub fn loaded_library_name() -> Option<&'static str> {
+    LIBRARY.get().map(|l| l.name.as_str())
+}
+
+/// Return a description of why the Botan library could not be loaded
+///
+/// Returns `None` if the library was loaded successfully or if loading has
+/// not yet been attempted.
+pub fn last_load_error() -> Option<&'static str> {
+    if LIBRARY.get().is_some() {
+        return None;
+    }
+    match *lock_state() {
+        State::AutoFailed(msg) => Some(msg),
+        State::Unattempted => None,
+    }
+}

--- a/botan-sys/src/macros.rs
+++ b/botan-sys/src/macros.rs
@@ -9,11 +9,19 @@
 //! (or the explicitly declared unavailable value for functions that do not
 //! return an error code).
 //!
+//! With the `dynamic-loading` feature the crate does not link against Botan
+//! at all. Instead the same macro expands to a wrapper function which loads
+//! the shared library on first use, resolves the symbol, and calls it,
+//! returning [`BOTAN_FFI_ERROR_FUNCTION_NOT_AVAILABLE`] if the loaded
+//! library does not export the symbol and
+//! [`BOTAN_FFI_ERROR_LIBRARY_NOT_LOADED`] if no library could be loaded.
+//!
 //! As a result every function is always callable, and callers only need to
-//! deal with a single runtime error condition ("the library in use does not
+//! deal with a runtime error condition ("the library in use does not
 //! provide this function") rather than a compile time one.
 //!
 //! [`BOTAN_FFI_ERROR_FUNCTION_NOT_AVAILABLE`]: crate::BOTAN_FFI_ERROR_FUNCTION_NOT_AVAILABLE
+//! [`BOTAN_FFI_ERROR_LIBRARY_NOT_LOADED`]: crate::BOTAN_FFI_ERROR_LIBRARY_NOT_LOADED
 
 /// Declare a set of Botan FFI functions
 ///
@@ -54,15 +62,40 @@ macro_rules! __botan_ffi_function {
         @dflt [ $($dflt:expr)? ]
         pub fn $name:ident ( $($arg:ident : $ty:ty),* ) $( -> $ret:ty )? ;
     ) => {
+        // Linked modes: the real declaration, if the detected headers have it
+        #[cfg(not(feature = "dynamic-loading"))]
         $( #[cfg($cfg)] )?
         unsafe extern "C" {
             pub fn $name ( $($arg : $ty),* ) $( -> $ret )? ;
         }
 
+        // Linked modes: a stub if the detected headers predate the function
         __botan_ffi_stub! {
             @cfg [ $($cfg)? ]
             @dflt [ $($dflt)? ]
             pub fn $name ( $($arg : $ty),* ) $( -> $ret )? ;
+        }
+
+        // Dynamic loading: resolve the symbol from the loaded library on
+        // first use, and call it. Missing symbols and a library which could
+        // not be loaded are reported via the return value.
+        #[cfg(feature = "dynamic-loading")]
+        #[allow(non_snake_case, clippy::missing_safety_doc)]
+        pub unsafe extern "C" fn $name ( $($arg : $ty),* ) $( -> $ret )? {
+            static SYM: $crate::loader::Symbol<unsafe extern "C" fn($($ty),*) $( -> $ret )?> =
+                $crate::loader::Symbol::new(concat!(stringify!($name), "\0"));
+
+            // SAFETY: the type of SYM matches the declaration of the function
+            match unsafe { SYM.get() } {
+                // SAFETY: calling the FFI function with its declared signature
+                Ok(f) => unsafe { f($($arg),*) },
+                Err($crate::loader::Unavailable::Function) => {
+                    __botan_unavailable_value!( $($dflt)? )
+                }
+                Err($crate::loader::Unavailable::Library) => {
+                    __botan_not_loaded_value!( $($dflt)? )
+                }
+            }
         }
     };
 }
@@ -79,7 +112,7 @@ macro_rules! __botan_ffi_stub {
         @dflt [ $($dflt:expr)? ]
         pub fn $name:ident ( $($arg:ident : $ty:ty),* ) $( -> $ret:ty )? ;
     ) => {
-        #[cfg(not($cfg))]
+        #[cfg(all(not(feature = "dynamic-loading"), not($cfg)))]
         #[allow(unused_variables, non_snake_case, clippy::missing_safety_doc)]
         #[doc = concat!("Stub for `", stringify!($name), "`, which is not provided by the version of Botan detected at build time (requires `", stringify!($cfg), "`).")]
         pub unsafe extern "C" fn $name ( $($arg : $ty),* ) $( -> $ret )? {
@@ -91,6 +124,15 @@ macro_rules! __botan_ffi_stub {
 macro_rules! __botan_unavailable_value {
     () => {
         $crate::BOTAN_FFI_ERROR_FUNCTION_NOT_AVAILABLE
+    };
+    ($dflt:expr) => {
+        $dflt
+    };
+}
+
+macro_rules! __botan_not_loaded_value {
+    () => {
+        $crate::BOTAN_FFI_ERROR_LIBRARY_NOT_LOADED
     };
     ($dflt:expr) => {
         $dflt

--- a/botan/Cargo.toml
+++ b/botan/Cargo.toml
@@ -27,7 +27,13 @@ std = []
 vendored = ["botan-sys/vendored"]
 static = ["botan-sys/static"]
 pkg-config = ["botan-sys/pkg-config"]
+dynamic-loading = ["botan-sys/dynamic-loading", "std"]
 rand = ["dep:rand_core"]
+
+# Build the docs with dynamic loading enabled so that its API is documented
+# (and no Botan installation is needed to build the docs)
+[package.metadata.docs.rs]
+features = ["dynamic-loading"]
 
 [lints.clippy]
 # introduced because of from_str

--- a/botan/src/dynamic_loading.rs
+++ b/botan/src/dynamic_loading.rs
@@ -1,0 +1,40 @@
+use crate::utils::*;
+
+/// Load the Botan shared library from the specified path or name
+///
+/// This is only available with the `dynamic-loading` feature.
+///
+/// If this is not called, the Botan shared library is searched for under its
+/// usual names (eg `libbotan-3.so.N`) the first time it is needed. Calling
+/// this function first allows an application to control exactly which
+/// library is used. The name is passed to `dlopen` (or `LoadLibrary`), so it
+/// may be a full path or a bare filename which is searched for in the usual
+/// locations.
+///
+/// This must be called before any other use of the library; once a library
+/// has been loaded it cannot be replaced, and this function fails with
+/// an error of type [`ErrorType::InvalidObjectState`].
+///
+/// If the library cannot be loaded, or is not a usable version of Botan, an
+/// error of type [`ErrorType::LibraryNotLoaded`] is returned.
+pub fn load_library<P: AsRef<std::ffi::OsStr>>(path: P) -> Result<()> {
+    match botan_sys::load_library(path) {
+        Ok(()) => Ok(()),
+        Err(botan_sys::LoadError::AlreadyLoaded) => Err(Error::with_message(
+            ErrorType::InvalidObjectState,
+            "A Botan library has already been loaded".to_owned(),
+        )),
+        Err(e) => Err(Error::with_message(
+            ErrorType::LibraryNotLoaded,
+            e.to_string(),
+        )),
+    }
+}
+
+/// Return the name or path of the Botan shared library which was loaded
+///
+/// This is only available with the `dynamic-loading` feature. Returns `None`
+/// if no library has been loaded yet.
+pub fn loaded_library_name() -> Option<&'static str> {
+    botan_sys::loaded_library_name()
+}

--- a/botan/src/lib.rs
+++ b/botan/src/lib.rs
@@ -3,6 +3,30 @@
 #![allow(unused_imports)]
 
 //! A wrapper for the Botan cryptography library
+//!
+//! # Linking to Botan
+//!
+//! By default the crate links against an installed Botan shared library
+//! (or a static library with the `static` feature, or one built from source
+//! with the `vendored` feature). Which functions the Botan headers declare
+//! is detected at build time.
+//!
+//! With the `dynamic-loading` feature nothing is linked at build time and no
+//! Botan installation is required to build. Instead the Botan shared library
+//! is located and loaded the first time it is needed (see `load_library`
+//! for how to control this), and functions are resolved from it as they are
+//! used. This means an application can be built once and pick up newer
+//! features when run against a newer Botan, without being rebuilt.
+//!
+//! # Availability of newer APIs
+//!
+//! Every wrapper in this crate exists regardless of the version of Botan it
+//! is built or run against. When an operation requires a function that the
+//! Botan library in use does not provide, an error of type
+//! [`ErrorType::NotImplemented`] is returned and [`Error::is_function_unavailable`]
+//! returns true. The documentation of each affected item notes the minimum
+//! version of Botan required. [`Version::current`] and
+//! [`Version::supports_version`] report on the library in use.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
@@ -189,3 +213,9 @@ mod spake2p;
 
 pub use pk_ops_kem::*;
 pub use spake2p::*;
+
+#[cfg(feature = "dynamic-loading")]
+mod dynamic_loading;
+
+#[cfg(feature = "dynamic-loading")]
+pub use dynamic_loading::*;

--- a/botan/src/memutils.rs
+++ b/botan/src/memutils.rs
@@ -4,6 +4,13 @@ use botan_sys::*;
 /// Const time comparison
 ///
 /// Compare two arrays without leaking side channel information
+///
+/// # Panics
+///
+/// Panics if the Botan library is not available, which is only possible
+/// when using dynamic loading and no library could be loaded. This function
+/// has no way of reporting an error, and silently returning an incorrect
+/// result would be worse.
 #[must_use]
 pub fn const_time_compare<T: Copy>(a: &[T], b: &[T]) -> bool {
     if a.len() != b.len() {
@@ -15,16 +22,37 @@ pub fn const_time_compare<T: Copy>(a: &[T], b: &[T]) -> bool {
         botan_constant_time_compare(a.as_ptr() as *const u8, b.as_ptr() as *const u8, bytes)
     };
 
-    rc == 0
+    // Returns 0 if equal, -1 if not; anything else means the call itself failed
+    match rc {
+        0 => true,
+        -1 => false,
+        rc => panic!(
+            "botan_constant_time_compare failed: {}",
+            Error::from_named_rc("botan_constant_time_compare", rc)
+        ),
+    }
 }
 
 /// Securely zeroize memory
 ///
 /// Write zeros to the array (eg to clear out a key) in a way that is
 /// unlikely to be removed by the compiler.
+///
+/// # Panics
+///
+/// Panics if the Botan library is not available, which is only possible
+/// when using dynamic loading and no library could be loaded. This function
+/// has no way of reporting an error, and silently leaving the memory
+/// unscrubbed would be worse.
 pub fn scrub_mem<T: Copy>(a: &mut [T]) {
     let bytes = mem::size_of_val(a);
-    unsafe { botan_scrub_mem(a.as_mut_ptr() as *mut c_void, bytes) };
+    let rc = unsafe { botan_scrub_mem(a.as_mut_ptr() as *mut c_void, bytes) };
+    if rc != 0 {
+        panic!(
+            "botan_scrub_mem failed: {}",
+            Error::from_named_rc("botan_scrub_mem", rc)
+        );
+    }
 }
 
 /// Hex encode some data

--- a/botan/tests/dynamic_loading.rs
+++ b/botan/tests/dynamic_loading.rs
@@ -1,0 +1,37 @@
+#![cfg(feature = "dynamic-loading")]
+
+// This test file runs in its own process, so it can observe the state of the
+// library loader before anything else has triggered loading
+
+#[test]
+fn test_dynamic_loading() -> Result<(), botan::Error> {
+    assert!(botan::loaded_library_name().is_none());
+
+    // Loading something that does not exist fails without affecting later loads
+    let err = botan::load_library("/nonexistent/path/libbotan-3.so").unwrap_err();
+    assert_eq!(err.error_type(), botan::ErrorType::LibraryNotLoaded);
+    assert!(botan::loaded_library_name().is_none());
+
+    // The first use triggers the default search
+    let version = botan::Version::current()?;
+    println!(
+        "Loaded {:?} from {:?}",
+        version,
+        botan::loaded_library_name()
+    );
+    let name = botan::loaded_library_name().expect("library was loaded");
+    assert!(name.contains("botan"));
+
+    // Once loaded the library cannot be replaced
+    let err = botan::load_library(name).unwrap_err();
+    assert_eq!(err.error_type(), botan::ErrorType::InvalidObjectState);
+
+    // And it works
+    let mut hash = botan::HashFunction::new("SHA-256")?;
+    hash.update(b"abc")?;
+    let digest = hash.finish()?;
+    assert_eq!(digest[0], 0xBA);
+    assert_eq!(digest[31], 0xAD);
+
+    Ok(())
+}


### PR DESCRIPTION
With the new `dynamic-loading` feature (botan-sys and botan) nothing is linked at build time and no Botan installation is needed to build. The shared library is located and loaded on first use, searching the usual names, or can be loaded
explicitly via `botan::load_library`. Every FFI function is resolved on first use, so a binary using this feature picks up newer Botan features simply by running against a newer library. This also allows applications using the library to pick up bug fixes in new versions of the C++ library without a relink.

Fixes #181 