### PR TITLE
Test on 26.04 and 24.04 images

### DIFF
--- a/.ci/build.py
+++ b/.ci/build.py
@@ -19,6 +19,41 @@ def run_command(cmdline, cwd = None):
         print("ERROR: Running %s failed with rc %d" % (cmdline, proc.returncode))
         sys.exit(1)
 
+def apt_package_available(pkg):
+    proc = subprocess.run(['apt-cache', 'show', pkg],
+                          stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    return proc.returncode == 0
+
+def apt_botan_packages():
+    """
+    Returns (dev_pkg, runtime_pkg) for the newest Botan the distribution provides.
+
+    Ubuntu 24.04 ships only Botan 2 (libbotan-2-dev / libbotan-2-19) while
+    Ubuntu 26.04 ships only Botan 3 (libbotan-3-dev / libbotan-3-10), so which
+    version gets tested is determined by the runner OS.
+    """
+    for major in [3, 2]:
+        dev_pkg = 'libbotan-%d-dev' % (major)
+        if not apt_package_available(dev_pkg):
+            continue
+
+        # The runtime package is named after the ABI revision (eg
+        # libbotan-3-10); find it via the dependencies of the -dev package
+        deps = subprocess.check_output(['apt-cache', 'depends', dev_pkg]).decode()
+        prefix = 'libbotan-%d-' % (major)
+        for line in deps.splitlines():
+            line = line.strip()
+            if line.startswith('Depends:'):
+                dep = line.split(':', 1)[1].strip()
+                if dep.startswith(prefix) and dep != dev_pkg:
+                    return (dev_pkg, dep)
+
+        print("ERROR: Unable to determine the runtime package for %s" % (dev_pkg))
+        sys.exit(1)
+
+    print("ERROR: No libbotan packages are available")
+    sys.exit(1)
+
 def compute_features(features, for_who):
     feat = []
     if 'vendored' in features:
@@ -160,13 +195,14 @@ def main(args = None):
         os.environ["RUSTDOCFLAGS"] = "-D warnings -L/opt/homebrew/lib"
         os.environ["DYLD_LIBRARY_PATH"] = homebrew_dir
     elif os.access('/usr/bin/apt-get', os.R_OK):
+        (dev_pkg, runtime_pkg) = apt_botan_packages()
         if 'dynamic' in features:
             # With dynamic loading no headers are needed to build, and the
             # library is located at runtime; install only the runtime package
             # to verify this
-            run_command(['sudo', 'apt-get', 'install', 'libbotan-2-19'])
+            run_command(['sudo', 'apt-get', 'install', runtime_pkg])
         else:
-            run_command(['sudo', 'apt-get', 'install', 'libbotan-2-dev'])
+            run_command(['sudo', 'apt-get', 'install', dev_pkg])
 
     run_command(['rustc', '--version'])
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   rustfmt:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     steps:
       - uses: dtolnay/rust-toolchain@master
@@ -20,10 +20,10 @@ jobs:
 
       - run: cargo fmt -- --check
   clippy:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     steps:
-      - run: sudo apt-get -qq install libbotan-2-dev
+      - run: sudo apt-get -qq install libbotan-3-dev
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
@@ -35,7 +35,7 @@ jobs:
       - run: cargo +nightly clippy --all-targets -- --deny warnings
       - run: cargo +nightly clippy --all-targets --features dynamic-loading -- --deny warnings
   ci:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
 
     env:
         RUST_BACKTRACE: 1
@@ -43,29 +43,51 @@ jobs:
     strategy:
       fail-fast: false
 
+      # Builds that use the system Botan (no git/vendored feature) test
+      # whichever Botan the distribution provides: Ubuntu 24.04 is the last
+      # release shipping Botan 2 (2.19), while Ubuntu 26.04 ships Botan 3
+      # (3.10), so such builds are run on both. Everything else runs on
+      # Ubuntu 26.04.
       matrix:
         include:
           - toolchain: stable
+            os: ubuntu-24.04
+          - toolchain: stable
+            os: ubuntu-26.04
           - toolchain: stable
             features: no-std+git
+            os: ubuntu-26.04
           - toolchain: stable
             features: git
+            os: ubuntu-26.04
           - toolchain: stable
             features: git+minimized
+            os: ubuntu-26.04
           - toolchain: stable
             features: vendored
+            os: ubuntu-26.04
           - toolchain: stable
             features: dynamic
+            os: ubuntu-24.04
+          - toolchain: stable
+            features: dynamic
+            os: ubuntu-26.04
           - toolchain: stable
             features: dynamic+git
+            os: ubuntu-26.04
           - toolchain: 1.85.1 # MSRV no-std
             features: no-std+git
+            os: ubuntu-26.04
           - toolchain: 1.85.1 # MSRV
+            os: ubuntu-24.04
           - toolchain: 1.85.1 # MSRV dynamic loading
             features: dynamic
+            os: ubuntu-24.04
           - toolchain: nightly
+            os: ubuntu-24.04
           - toolchain: nightly
             features: no-std+git
+            os: ubuntu-26.04
 
     steps:
       - run: sudo apt-get -qq install ccache
@@ -74,9 +96,9 @@ jobs:
         with:
             path: |
               ~/.cache/ccache
-            key: linux-x86_64-${{ matrix.toolchain }}-${{ matrix.features }}-${{ github.run_id }}
+            key: ${{ matrix.os }}-${{ matrix.toolchain }}-${{ matrix.features }}-${{ github.run_id }}
             restore-keys: |
-               linux-x86_64-${{ matrix.toolchain }}-${{ matrix.features }}
+               ${{ matrix.os }}-${{ matrix.toolchain }}-${{ matrix.features }}
       - uses: dtolnay/rust-toolchain@master
         with:
           target: ${{ matrix.target }}
@@ -84,7 +106,7 @@ jobs:
       - run: ./.ci/build.py ${{ matrix.toolchain }} ${{ matrix.features }}
 
   ci_arm:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ${{ matrix.os }}
 
     env:
         RUST_BACKTRACE: 1
@@ -92,14 +114,21 @@ jobs:
     strategy:
       fail-fast: false
 
+      # See the comment on the ci job regarding the OS selection
       matrix:
         include:
           - toolchain: stable
+            os: ubuntu-24.04-arm
+          - toolchain: stable
+            os: ubuntu-26.04-arm
           - toolchain: stable
             features: git
+            os: ubuntu-26.04-arm
           - toolchain: stable
             features: dynamic
+            os: ubuntu-24.04-arm
           - toolchain: nightly
+            os: ubuntu-24.04-arm
 
     steps:
       - run: sudo apt-get -qq install ccache
@@ -108,9 +137,9 @@ jobs:
         with:
             path: |
               ~/.cache/ccache
-            key: linux-aarch64-${{ matrix.toolchain }}-${{ matrix.features }}-${{ github.run_id }}
+            key: ${{ matrix.os }}-${{ matrix.toolchain }}-${{ matrix.features }}-${{ github.run_id }}
             restore-keys: |
-               linux-aarch64-${{ matrix.toolchain }}-${{ matrix.features }}
+               ${{ matrix.os }}-${{ matrix.toolchain }}-${{ matrix.features }}
       - uses: dtolnay/rust-toolchain@master
         with:
           target: ${{ matrix.target }}


### PR DESCRIPTION
If not using the system's libbotan, just run on 26.04. For tests using the system library, run on both images so we can test the Ubuntu Botan2 and Botan3 packages.