### PR TITLE
Skip archive link entries when extracting Botan on Windows

### DIFF
--- a/botan-src/src/lib.rs
+++ b/botan-src/src/lib.rs
@@ -148,6 +148,23 @@ fn extract_tarball(tarball: &Path, dest: &Path) {
     let mut decompressed = Vec::new();
     lzma_rs::xz_decompress(&mut reader, &mut decompressed).expect("xz decompress");
     let mut archive = tar::Archive::new(io::Cursor::new(decompressed));
+
+    // Windows without Developer Mode (or admin rights) cannot create symlinks.
+    // The Botan tarball contains a handful of symlinks (e.g. .github/codecov.yml)
+    // that are not needed to build the library. Skip them on Windows only.
+    #[cfg(target_os = "windows")]
+    {
+        for entry in archive.entries().expect("read archive entries") {
+            let mut entry = entry.expect("read archive entry");
+            let entry_type = entry.header().entry_type();
+            if entry_type.is_symlink() || entry_type.is_hard_link() {
+                continue;
+            }
+            entry.unpack_in(dest).expect("unpack entry");
+        }
+    }
+
+    #[cfg(not(target_os = "windows"))]
     archive.unpack(dest).expect("untar");
 }
 


### PR DESCRIPTION
Extract Botan source archives entry by entry on Windows and skip symbolic-link and hard-link entries.

Other platforms continue to use the existing full-archive extraction behavior.

Creating symbolic links on Windows commonly requires Developer Mode or elevated privileges. Consequently, extracting the Botan source archive can fail in developer environments and CI runners, even though its link entries are not required to build the library.